### PR TITLE
Update scindex.html

### DIFF
--- a/scindex.html
+++ b/scindex.html
@@ -132,7 +132,7 @@
 									<p class="lead">阅读我们的白皮书以了解有关SNGLS媒体发行协定及SNGLS DAO的更多信息。</p>
 									<a href="files/SNGLSDAO-wp-eng.pdf"
 									   class="btn btn-red btn-sm" style="margin-right: 15px;">英文版</a>
-									<a href=files/SNGLSDAO-wp-tc.pdf"
+									<a href="files/SNGLSDAO-wp-tc.pdf"
 									   class="btn btn-red btn-sm">中文版</a>
 								</div>
 								<div class="col-sm-5">


### PR DESCRIPTION
@DannyDesert @miladmostavi the SC webpage download whitepaper button link is not working because of a missing " in the <a href src=> tag. I updated the code in this pull request. The new SC website file "scindex.html" need to be replaced on the website server. Thanks.